### PR TITLE
feat: añadir menú de inicio y panel de música

### DIFF
--- a/app/components/MusicPlayer.vue
+++ b/app/components/MusicPlayer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative">
+  <div>
     <Motion
       as="button"
       class="w-8 h-8 flex items-center justify-center rounded hover:bg-pink-200"
@@ -14,10 +14,10 @@
       <Motion
         v-if="playerOpen"
         key="player"
-        class="absolute bottom-12 left-0 w-56 bg-white rounded-xl shadow-xl border border-pink-100 p-4"
-        :initial="{ opacity: 0, y: 20 }"
-        :animate="{ opacity: 1, y: 0 }"
-        :exit="{ opacity: 0, y: 20 }"
+        class="fixed top-0 bottom-12 right-0 w-64 bg-white shadow-xl border-l border-pink-100 p-4"
+        :initial="{ opacity: 0, x: 100 }"
+        :animate="{ opacity: 1, x: 0 }"
+        :exit="{ opacity: 0, x: 100 }"
         :transition="{ duration: 0.3 }"
       >
         <select v-model="selected" class="w-full text-sm bg-white rounded px-2 py-1 border-pink-200">

--- a/app/components/StartMenu.vue
+++ b/app/components/StartMenu.vue
@@ -11,9 +11,11 @@
     >
       <h3 class="font-semibold text-pink-700 mb-2">📂 Inicio</h3>
       <ul class="grid grid-cols-2 gap-3">
-        <li class="text-center text-sm hover:scale-105 transition cursor-pointer">💌 Carta</li>
         <li class="text-center text-sm hover:scale-105 transition cursor-pointer">🎮 Juegos</li>
-        <li class="text-center text-sm hover:scale-105 transition cursor-pointer">🖼️ Galería</li>
+        <li class="text-center text-sm hover:scale-105 transition cursor-pointer">📝 Notas</li>
+        <li class="text-center text-sm hover:scale-105 transition cursor-pointer">🧮 Calculadora</li>
+        <li class="text-center text-sm hover:scale-105 transition cursor-pointer">🎵 Música</li>
+        <li class="text-center text-sm hover:scale-105 transition cursor-pointer">📸 Fotos</li>
       </ul>
       <button @click="toggleStart" class="block mt-4 text-xs text-right text-pink-500 hover:underline">Cerrar</button>
     </Motion>

--- a/app/components/Taskbar.vue
+++ b/app/components/Taskbar.vue
@@ -13,9 +13,9 @@
         🪟
       </button>
 
-      <MusicPlayer class="ml-2" />
-
       <div class="flex-1" />
+
+      <MusicPlayer class="mr-2" />
 
       <div class="text-sm px-2">{{ currentTime }}</div>
     </Motion>


### PR DESCRIPTION
## Summary
- agrega opciones de juegos, notas, calculadora, música y fotos al menú de inicio
- sitúa el icono de música al extremo derecho y muestra un panel lateral con las canciones disponibles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890f2cf714c83308d5bb16fbcee5df0