### PR TITLE
fix: prevent undefined window access

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -8,17 +8,18 @@
     <Icon app="tictactoe" label="3 en raya" :x="100" :y="180">⭕</Icon>
 
     <AnimatePresence>
-      <Window
-        v-for="(win, id) in windows"
-        v-if="!win.minimized"
-        :key="id"
-        :id="id"
-        :title="titles[id]"
-        :x="200"
-        :y="80"
-      >
-        <component :is="apps[id]" />
-      </Window>
+      <template v-for="(win, id) in windows">
+        <Window
+          v-if="!win.minimized"
+          :key="id"
+          :id="id"
+          :title="titles[id]"
+          :x="200"
+          :y="80"
+        >
+          <component :is="apps[id]" />
+        </Window>
+      </template>
     </AnimatePresence>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- avoid accessing `minimized` before `win` is defined

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890faa880e88330b2e59a00f33cd85e