### PR TITLE
Wrap pet message interval in client-only lifecycle

### DIFF
--- a/app/components/ui/Pet.vue
+++ b/app/components/ui/Pet.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { Motion } from 'motion-v'
 
 const phrases = [
@@ -33,5 +33,13 @@ function petClick() {
   setTimeout(() => (pet.value = '🐱'), 1000)
 }
 
-setInterval(randomMessage, 10000)
+let interval: ReturnType<typeof setInterval>
+
+onMounted(() => {
+  interval = setInterval(randomMessage, 10000)
+})
+
+onUnmounted(() => {
+  clearInterval(interval)
+})
 </script>


### PR DESCRIPTION
## Summary
- avoid server-side interval in `Pet` component by starting it in `onMounted` and cleaning up in `onUnmounted`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689101632974833087fa19992dbd2376