### PR TITLE
Add adorable desktop decorations and animations

### DIFF
--- a/app/components/desktop/DesktopClock.vue
+++ b/app/components/desktop/DesktopClock.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="absolute top-4 left-1/2 -translate-x-1/2 text-3xl text-rose-500 flex items-center gap-2 pointer-events-none z-30">
+    <span>{{ time }}</span>
+    <span>😊</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const time = ref('')
+let interval: ReturnType<typeof setInterval>
+
+const update = () => {
+  const now = new Date()
+  time.value = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+onMounted(() => {
+  update()
+  interval = setInterval(update, 1000)
+})
+
+onUnmounted(() => clearInterval(interval))
+</script>

--- a/app/components/desktop/FloatingElements.vue
+++ b/app/components/desktop/FloatingElements.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="pointer-events-none fixed inset-0 z-0 overflow-hidden">
+    <Motion
+      v-for="(el, i) in elements"
+      :key="i"
+      class="absolute text-3xl opacity-80"
+      :style="{ top: el.top + '%', left: el.left + '%' }"
+      :animate="{ y: [0, -el.float, 0] }"
+      :transition="{ duration: el.duration, repeat: Infinity, repeatType: 'reverse' }"
+    >
+      <component :is="el.component" />
+    </Motion>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { h } from 'vue'
+import { Motion } from 'motion-v'
+
+const elements = [
+  { component: () => h('span', '💖'), top: 20, left: 10, float: 20, duration: 8 },
+  { component: () => h('span', '🌟'), top: 70, left: 80, float: 15, duration: 6 },
+  { component: () => h('img', { src: '/cute/cat.svg', class: 'w-8 h-8' }), top: 40, left: 50, float: 25, duration: 10 }
+]
+</script>

--- a/app/components/desktop/Icon.vue
+++ b/app/components/desktop/Icon.vue
@@ -1,28 +1,39 @@
 <template>
-  <div
-    class="absolute w-16 text-center cursor-pointer select-none"
+  <Motion
+    class="absolute text-center cursor-pointer select-none z-10 rounded-xl transition-shadow"
+    :class="sizeClass"
     :style="{ left: position.x + 'px', top: position.y + 'px' }"
     @dblclick="openApp"
     @mousedown.prevent="startDrag"
+    :while-hover="{ scale: 1.1 }"
   >
-    <div class="flex flex-col items-center">
+    <div class="flex flex-col items-center justify-center h-full w-full">
       <slot />
       <span class="mt-1 text-xs text-pink-700">{{ label }}</span>
     </div>
-  </div>
+  </Motion>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { Motion } from 'motion-v'
 import { useWindows } from '~/composables/useWindows'
+import { useIconMode } from '~/composables/useIconMode'
 
 const props = defineProps<{ app: string; label: string; x?: number; y?: number }>()
 const { open } = useWindows()
+const { mode } = useIconMode()
 
 const position = ref({ x: props.x ?? 20, y: props.y ?? 20 })
 let startX = 0
 let startY = 0
 let dragging = false
+
+const sizeClass = computed(() =>
+  mode.value === 'large'
+    ? 'w-20 h-20 text-4xl hover:shadow-lg hover:shadow-pink-200'
+    : 'w-12 h-12 text-2xl hover:shadow-md hover:shadow-pink-200'
+)
 
 function startDrag(e: MouseEvent) {
   dragging = true

--- a/app/components/desktop/RomanticPopup.vue
+++ b/app/components/desktop/RomanticPopup.vue
@@ -1,0 +1,39 @@
+<template>
+  <ClientOnly>
+    <AnimatePresence>
+      <Motion
+        v-if="visible"
+        key="popup"
+        class="fixed top-20 right-6 w-56 bg-white border border-pink-200 rounded-xl shadow-xl p-4 text-pink-700 z-40"
+        :initial="{ opacity: 0, scale: 0.8 }"
+        :animate="{ opacity: 1, scale: 1 }"
+        :exit="{ opacity: 0, scale: 0.8 }"
+        :transition="{ duration: 0.3 }"
+      >
+        <button class="absolute top-1 right-2 text-pink-400" @click="visible = false">✖</button>
+        <p class="text-sm">{{ message }}</p>
+      </Motion>
+    </AnimatePresence>
+  </ClientOnly>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { Motion, AnimatePresence } from 'motion-v'
+
+const messages = [
+  '¡Recuerda que eres amada! 💖',
+  'Nuevo abrazo disponible para recoger 🤗',
+  'Alguien piensa en ti ahora mismo...'
+]
+
+const visible = ref(false)
+const message = ref('')
+
+onMounted(() => {
+  setTimeout(() => {
+    message.value = messages[Math.floor(Math.random() * messages.length)]
+    visible.value = true
+  }, 2000)
+})
+</script>

--- a/app/components/desktop/StartMenu.vue
+++ b/app/components/desktop/StartMenu.vue
@@ -21,7 +21,12 @@
             {{ item.icon }} {{ item.label }}
           </li>
         </ul>
-        <button @click="toggleStart" class="block mt-4 text-xs text-right text-pink-500 hover:underline">Cerrar</button>
+        <div class="mt-4 flex items-center justify-between text-xs">
+          <button @click="toggle" class="px-2 py-1 rounded bg-rose-100 text-pink-700">
+            {{ mode === 'large' ? 'Iconos grandes' : 'Iconos mini' }}
+          </button>
+          <button @click="toggleStart" class="text-pink-500 hover:underline">Cerrar</button>
+        </div>
       </Motion>
     </AnimatePresence>
   </ClientOnly>
@@ -31,9 +36,11 @@
 import { Motion, AnimatePresence } from 'motion-v'
 import { useTaskbar } from '~/composables/useTaskbar'
 import { useWindows } from '~/composables/useWindows'
+import { useIconMode } from '~/composables/useIconMode'
 
 const { startOpen, toggleStart } = useTaskbar()
 const { open } = useWindows()
+const { mode, toggle } = useIconMode()
 
 const items = [
   { id: 'music', label: 'Música', icon: '🎵' },

--- a/app/composables/useIconMode.ts
+++ b/app/composables/useIconMode.ts
@@ -1,0 +1,9 @@
+import { useState } from '#app'
+
+export function useIconMode() {
+  const mode = useState<'mini' | 'large'>('icon-mode', () => 'large')
+  const toggle = () => {
+    mode.value = mode.value === 'large' ? 'mini' : 'large'
+  }
+  return { mode, toggle }
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="w-screen h-screen bg-pink-50 relative overflow-hidden">
+  <div
+    class="w-screen h-screen bg-pink-50 relative overflow-hidden border-8 border-rose-100 rounded-xl [background-image:radial-gradient(circle,_rgba(255,255,255,0.6)_1px,_transparent_1px)] [background-size:20px_20px]"
+  >
+    <FloatingElements />
+    <DesktopClock />
+    <RomanticPopup />
     <Icon app="music" label="Música" :x="20" :y="20">🎵</Icon>
     <Icon app="snake" label="Snake" :x="20" :y="100">🐍</Icon>
     <Icon app="calc" label="Calc" :x="20" :y="180">🧮</Icon>
@@ -12,6 +17,16 @@
     <Icon app="sorpresa" label="Sorpresa" :x="260" :y="20">🎁</Icon>
     <Icon app="recuerdos" label="Recuerdos" :x="260" :y="100">📦</Icon>
     <Icon app="tv" label="TV" :x="260" :y="180">📺</Icon>
+    <img
+      src="/cute/cat.svg"
+      class="absolute bottom-2 left-2 w-16 h-16 opacity-80 pointer-events-none"
+      alt="gatito"
+    />
+    <img
+      src="/cute/bow.svg"
+      class="absolute top-2 right-2 w-12 h-12 opacity-70 pointer-events-none"
+      alt="moño"
+    />
 
     <AnimatePresence>
       <template v-for="(win, id) in windows">
@@ -34,6 +49,9 @@
 import { AnimatePresence } from 'motion-v'
 import Icon from '~/components/desktop/Icon.vue'
 import Window from '~/components/desktop/Window.vue'
+import FloatingElements from '~/components/desktop/FloatingElements.vue'
+import RomanticPopup from '~/components/desktop/RomanticPopup.vue'
+import DesktopClock from '~/components/desktop/DesktopClock.vue'
 import MusicPlayer from '~/components/apps/MusicPlayer.vue'
 import SnakeGame from '~/components/apps/SnakeGame.vue'
 import BrokenCalculator from '~/components/apps/BrokenCalculator.vue'


### PR DESCRIPTION
## Summary
- Enlarge desktop icons with hover glow and size toggle
- Add floating decorative elements and romantic popup
- Introduce desktop clock and cute stickers with patterned background

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")

------
https://chatgpt.com/codex/tasks/task_e_68911301b03c833084c20beadea6ff8b